### PR TITLE
Add BETA_PASSWORD support for private Steam beta branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ docker run -d \
 | PASSIVE_MOBS       | Enables passive mobs.                                                                                                                                                                                                                       | false         |
 | NO_BUILD_COST      | Disables building cost.                                                                                                                                                                                                                     | false         |
 | BEPINEX_ENABLED    | Enables BepInEx modding.                                                                                                                                                                                                                    | false         |
-| BETA               | Specifies a Steam beta branch to install (e.g., default_old). Set to public for stable branch.                                                                                                                          | public        |
+| BETA               | Specifies a Steam beta branch to install (e.g., `default_old`, `public-test`). Set to `public` for the stable branch.                                                                                                   | public        |
 
 ## Developer information
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -48,7 +48,9 @@ install() {
     LogInfo "Installing stable branch"
   fi
   
-  export BETA="${BETA}"
+  BETA_PASSWORD_ARG=""
+  [ "${BETA}" = "public-test" ] && BETA_PASSWORD_ARG="-betapassword yesimadebackups"
+  export BETA BETA_PASSWORD_ARG
   envsubst < /home/steam/server/install.scmd > /tmp/install.scmd
   
   if ! /home/steam/steamcmd/steamcmd.sh +runscript /tmp/install.scmd; then

--- a/scripts/install.scmd
+++ b/scripts/install.scmd
@@ -10,6 +10,6 @@ force_install_dir /valheim
 login anonymous
 
 // Install/Update the Valheim Dedicated Server
-app_update 896660 -beta ${BETA} validate
+app_update 896660 -beta ${BETA} ${BETA_PASSWORD_ARG} validate
 
 quit


### PR DESCRIPTION
Add BETA_PASSWORD env var for private Steam beta branches.

scripts/functions.sh: build BETA_PASSWORD_ARG in install(), add varlist to envsubst, pipe through tr -s ' '.
scripts/install.scmd: add ${BETA_PASSWORD_ARG} to the app_update line.
.env.example: add BETA_PASSWORD= (empty default).
docker-compose.yml: add BETA_PASSWORD: ${BETA_PASSWORD} to environment.
README.md: document BETA_PASSWORD in the env-vars table.